### PR TITLE
[#25] 결제관련 entity 생성 및 설계

### DIFF
--- a/src/main/java/me/jjeda/mall/accounts/dto/AccountDto.java
+++ b/src/main/java/me/jjeda/mall/accounts/dto/AccountDto.java
@@ -15,10 +15,8 @@ import java.time.LocalDateTime;
 import java.util.Set;
 
 //@JsonIgnoreProperties({"email", "password", "phone", "address", "accountRole"})
-@AllArgsConstructor
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AccountDto {
 
     private Long id;

--- a/src/main/java/me/jjeda/mall/orders/controller/BuyerOrderController.java
+++ b/src/main/java/me/jjeda/mall/orders/controller/BuyerOrderController.java
@@ -71,4 +71,9 @@ public class BuyerOrderController {
 
         return ResponseEntity.ok(orderResource);
     }
+
+    @PostMapping("/{orderId}/payments")
+    public ResponseEntity payForOrder(@PathVariable Long orderId) {
+
+    }
 }

--- a/src/main/java/me/jjeda/mall/orders/controller/BuyerOrderController.java
+++ b/src/main/java/me/jjeda/mall/orders/controller/BuyerOrderController.java
@@ -71,9 +71,4 @@ public class BuyerOrderController {
 
         return ResponseEntity.ok(orderResource);
     }
-
-    @PostMapping("/{orderId}/payments")
-    public ResponseEntity payForOrder(@PathVariable Long orderId) {
-
-    }
 }

--- a/src/main/java/me/jjeda/mall/orders/controller/PaymentController.java
+++ b/src/main/java/me/jjeda/mall/orders/controller/PaymentController.java
@@ -1,0 +1,19 @@
+package me.jjeda.mall.orders.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/orders/payment")
+public class PaymentController {
+
+    @PostMapping
+    public ResponseEntity payForOrder() {
+
+        //TODO : factory 패턴을 통해 client 에서 받아온 메시지의 PaymentType 에 따라 PaymentService 를 주입받는다.
+        // final PaymentService paymentService = PaymentFactory.getType();
+        return null;
+    }
+}

--- a/src/main/java/me/jjeda/mall/orders/controller/PaymentController.java
+++ b/src/main/java/me/jjeda/mall/orders/controller/PaymentController.java
@@ -2,8 +2,8 @@ package me.jjeda.mall.orders.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.jjeda.mall.orders.domain.PaymentFactory;
-import me.jjeda.mall.orders.domain.PaymentType;
 import me.jjeda.mall.orders.dto.PaymentDto;
+import me.jjeda.mall.orders.service.OrderService;
 import me.jjeda.mall.orders.service.PaymentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequestMapping("/api/orders/payment")
@@ -19,13 +18,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class PaymentController {
 
     private final PaymentFactory paymentFactory;
+    private final OrderService orderService;
 
     @PostMapping(value = "/{orderId}")
-    public ResponseEntity payForOrder(@RequestBody PaymentDto paymentDto, @PathVariable Long orderId) {
-
+    public ResponseEntity completePayment(@RequestBody PaymentDto paymentDto, @PathVariable Long orderId) {
         final PaymentService paymentService = paymentFactory.getType(paymentDto.getPaymentType());
-
-        return ResponseEntity.ok(paymentService.payForOrder(paymentDto, orderId));
+        return ResponseEntity.ok(orderService.completePayment(paymentService, paymentDto, orderId));
     }
-
 }

--- a/src/main/java/me/jjeda/mall/orders/controller/PaymentController.java
+++ b/src/main/java/me/jjeda/mall/orders/controller/PaymentController.java
@@ -1,19 +1,31 @@
 package me.jjeda.mall.orders.controller;
 
+import lombok.RequiredArgsConstructor;
+import me.jjeda.mall.orders.domain.PaymentFactory;
+import me.jjeda.mall.orders.domain.PaymentType;
+import me.jjeda.mall.orders.dto.PaymentDto;
+import me.jjeda.mall.orders.service.PaymentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequestMapping("/api/orders/payment")
+@RequiredArgsConstructor
 public class PaymentController {
 
-    @PostMapping
-    public ResponseEntity payForOrder() {
+    private final PaymentFactory paymentFactory;
 
-        //TODO : factory 패턴을 통해 client 에서 받아온 메시지의 PaymentType 에 따라 PaymentService 를 주입받는다.
-        // final PaymentService paymentService = PaymentFactory.getType();
-        return null;
+    @PostMapping(value = "/{orderId}")
+    public ResponseEntity payForOrder(@RequestBody PaymentDto paymentDto, @PathVariable Long orderId) {
+
+        final PaymentService paymentService = paymentFactory.getType(paymentDto.getPaymentType());
+
+        return ResponseEntity.ok(paymentService.payForOrder(paymentDto, orderId));
     }
+
 }

--- a/src/main/java/me/jjeda/mall/orders/domain/CashPayment.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/CashPayment.java
@@ -1,0 +1,23 @@
+package me.jjeda.mall.orders.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CashPayment extends Payment {
+
+    private String bank;
+
+    private String bankAccount;
+
+    private String name;
+}

--- a/src/main/java/me/jjeda/mall/orders/domain/CashPayment.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/CashPayment.java
@@ -6,18 +6,31 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
 
 @Getter
 @Setter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class CashPayment extends Payment {
+public class CashPayment {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "cash_payment_id")
+    private Long id;
 
     private String bank;
 
     private String bankAccount;
 
     private String name;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Payment payment;
 }

--- a/src/main/java/me/jjeda/mall/orders/domain/CashPayment.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/CashPayment.java
@@ -2,6 +2,7 @@ package me.jjeda.mall.orders.domain;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,11 +12,13 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 
 @Getter
 @Setter
 @Entity
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class CashPayment {
@@ -32,5 +35,6 @@ public class CashPayment {
     private String name;
 
     @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id")
     private Payment payment;
 }

--- a/src/main/java/me/jjeda/mall/orders/domain/CreditPayment.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/CreditPayment.java
@@ -2,6 +2,7 @@ package me.jjeda.mall.orders.domain;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,11 +12,13 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 
 @Getter
 @Setter
 @Entity
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class CreditPayment {
@@ -32,6 +35,7 @@ public class CreditPayment {
     private String name;
 
     @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id")
     private Payment payment;
 
 }

--- a/src/main/java/me/jjeda/mall/orders/domain/CreditPayment.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/CreditPayment.java
@@ -6,19 +6,32 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
 
 @Getter
 @Setter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class CreditPayment extends Payment {
+public class CreditPayment {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "credit_payment_id")
+    private Long id;
 
     private String bank;
 
     private String cardNumber;
 
     private String name;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Payment payment;
 
 }

--- a/src/main/java/me/jjeda/mall/orders/domain/CreditPayment.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/CreditPayment.java
@@ -1,0 +1,24 @@
+package me.jjeda.mall.orders.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreditPayment extends Payment {
+
+    private String bank;
+
+    private String cardNumber;
+
+    private String name;
+
+}

--- a/src/main/java/me/jjeda/mall/orders/domain/MobilePayment.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/MobilePayment.java
@@ -3,6 +3,7 @@ package me.jjeda.mall.orders.domain;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,11 +13,13 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 
 @Getter
 @Setter
 @Entity
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class MobilePayment {
@@ -33,5 +36,6 @@ public class MobilePayment {
     private String name;
 
     @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id")
     private Payment payment;
 }

--- a/src/main/java/me/jjeda/mall/orders/domain/MobilePayment.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/MobilePayment.java
@@ -1,0 +1,24 @@
+package me.jjeda.mall.orders.domain;
+
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class MobilePayment extends Payment {
+
+    private String phone;
+
+    private String telco;
+
+    private String name;
+}

--- a/src/main/java/me/jjeda/mall/orders/domain/MobilePayment.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/MobilePayment.java
@@ -7,18 +7,31 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
 
 @Getter
 @Setter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class MobilePayment extends Payment {
+public class MobilePayment {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "mobile_payment_id")
+    private Long id;
 
     private String phone;
 
     private String telco;
 
     private String name;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Payment payment;
 }

--- a/src/main/java/me/jjeda/mall/orders/domain/Order.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/Order.java
@@ -1,6 +1,5 @@
 package me.jjeda.mall.orders.domain;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -53,6 +52,11 @@ public class Order {
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<OrderItem> orderItems;
+
+    private int totalPrice;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private Payment payment;
 
     private LocalDateTime orderAt;
 

--- a/src/main/java/me/jjeda/mall/orders/domain/Order.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/Order.java
@@ -56,6 +56,7 @@ public class Order {
     private int totalPrice;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "payment_id")
     private Payment payment;
 
     private LocalDateTime orderAt;

--- a/src/main/java/me/jjeda/mall/orders/domain/Payment.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/Payment.java
@@ -2,26 +2,25 @@ package me.jjeda.mall.orders.domain;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.Column;
-import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
 
 @Entity
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-@Inheritance(strategy = InheritanceType.JOINED)
-@DiscriminatorColumn
-public abstract class Payment {
+public class Payment {
 
     @Id
     @GeneratedValue
@@ -29,4 +28,12 @@ public abstract class Payment {
     private Long id;
 
     private int price;
+
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus paymentStatus;
+
+    @Enumerated(EnumType.STRING)
+    private PaymentType paymentType;
+
+
 }

--- a/src/main/java/me/jjeda/mall/orders/domain/Payment.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/Payment.java
@@ -38,5 +38,13 @@ public class Payment {
 
     private LocalDateTime createdAt;
 
+    /**
+     * 주문이 완료되면 결제대기상태의 결제 Entity 를 만들기 위한 메서드
+     */
+    public static Payment toReadyEntity() {
+        return Payment.builder()
+                .paymentStatus(PaymentStatus.READY)
+                .build();
+    }
 
 }

--- a/src/main/java/me/jjeda/mall/orders/domain/Payment.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/Payment.java
@@ -1,0 +1,32 @@
+package me.jjeda.mall.orders.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
+public abstract class Payment {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "payment_id")
+    private Long id;
+
+    private int price;
+}

--- a/src/main/java/me/jjeda/mall/orders/domain/Payment.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/Payment.java
@@ -13,6 +13,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -34,6 +35,8 @@ public class Payment {
 
     @Enumerated(EnumType.STRING)
     private PaymentType paymentType;
+
+    private LocalDateTime createdAt;
 
 
 }

--- a/src/main/java/me/jjeda/mall/orders/domain/PaymentAdapter.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/PaymentAdapter.java
@@ -6,6 +6,15 @@ import me.jjeda.mall.orders.dto.MobilePaymentDto;
 import me.jjeda.mall.orders.dto.PaymentDto;
 
 public class PaymentAdapter {
+    public static Payment toEntity(PaymentDto paymentDto) {
+        return Payment.builder()
+                .id(paymentDto.getId())
+                .price(paymentDto.getPrice())
+                .createdAt(paymentDto.getCreatedAt())
+                .paymentType(paymentDto.getPaymentType())
+                .paymentStatus(paymentDto.getPaymentStatus())
+                .build();
+    }
 
     public static CashPayment toEntity(CashPaymentDto cashPaymentDto) {
         return CashPayment.builder()
@@ -13,6 +22,7 @@ public class PaymentAdapter {
                 .bank(cashPaymentDto.getBank())
                 .bankAccount(cashPaymentDto.getBankAccount())
                 .name(cashPaymentDto.getName())
+                .payment(toEntity(cashPaymentDto.getSuperTypePaymentDto()))
                 .build();
     }
 
@@ -22,6 +32,7 @@ public class PaymentAdapter {
                 .bank(creditPaymentDto.getBank())
                 .cardNumber(creditPaymentDto.getCardNumber())
                 .name(creditPaymentDto.getName())
+                .payment(toEntity(creditPaymentDto.getSuperTypePaymentDto()))
                 .build();
     }
 
@@ -31,6 +42,7 @@ public class PaymentAdapter {
                 .phone(mobilePaymentDto.getPhone())
                 .telco(mobilePaymentDto.getTelco())
                 .name(mobilePaymentDto.getName())
+                .payment(toEntity(mobilePaymentDto.getSuperTypePaymentDto()))
                 .build();
     }
 
@@ -50,7 +62,6 @@ public class PaymentAdapter {
                 .bank(cashPayment.getBank())
                 .bankAccount(cashPayment.getBankAccount())
                 .name(cashPayment.getName())
-                .paymentDto(toDto(cashPayment.getPayment()))
                 .build();
     }
 
@@ -60,7 +71,6 @@ public class PaymentAdapter {
                 .bank(creditPayment.getBank())
                 .cardNumber(creditPayment.getCardNumber())
                 .name(creditPayment.getName())
-                .paymentDto(toDto(creditPayment.getPayment()))
                 .build();
     }
 
@@ -70,7 +80,6 @@ public class PaymentAdapter {
                 .phone(mobilePayment.getPhone())
                 .telco(mobilePayment.getTelco())
                 .name(mobilePayment.getName())
-                .paymentDto(toDto(mobilePayment.getPayment()))
                 .build();
     }
 }

--- a/src/main/java/me/jjeda/mall/orders/domain/PaymentAdapter.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/PaymentAdapter.java
@@ -1,0 +1,76 @@
+package me.jjeda.mall.orders.domain;
+
+import me.jjeda.mall.orders.dto.CashPaymentDto;
+import me.jjeda.mall.orders.dto.CreditPaymentDto;
+import me.jjeda.mall.orders.dto.MobilePaymentDto;
+import me.jjeda.mall.orders.dto.PaymentDto;
+
+public class PaymentAdapter {
+
+    public static CashPayment toEntity(CashPaymentDto cashPaymentDto) {
+        return CashPayment.builder()
+                .id(cashPaymentDto.getCashPaymentId())
+                .bank(cashPaymentDto.getBank())
+                .bankAccount(cashPaymentDto.getBankAccount())
+                .name(cashPaymentDto.getName())
+                .build();
+    }
+
+    public static CreditPayment toEntity(CreditPaymentDto creditPaymentDto) {
+        return CreditPayment.builder()
+                .id(creditPaymentDto.getCreditPaymentId())
+                .bank(creditPaymentDto.getBank())
+                .cardNumber(creditPaymentDto.getCardNumber())
+                .name(creditPaymentDto.getName())
+                .build();
+    }
+
+    public static MobilePayment toEntity(MobilePaymentDto mobilePaymentDto) {
+        return MobilePayment.builder()
+                .id(mobilePaymentDto.getMobilePaymentId())
+                .phone(mobilePaymentDto.getPhone())
+                .telco(mobilePaymentDto.getTelco())
+                .name(mobilePaymentDto.getName())
+                .build();
+    }
+
+    public static PaymentDto toDto(Payment payment) {
+        return PaymentDto.builder()
+                .id(payment.getId())
+                .price(payment.getPrice())
+                .paymentStatus(payment.getPaymentStatus())
+                .paymentType(payment.getPaymentType())
+                .createdAt(payment.getCreatedAt())
+                .build();
+    }
+
+    public static PaymentDto toDto(CashPayment cashPayment) {
+        return CashPaymentDto.builder()
+                .cashPaymentId(cashPayment.getId())
+                .bank(cashPayment.getBank())
+                .bankAccount(cashPayment.getBankAccount())
+                .name(cashPayment.getName())
+                .paymentDto(toDto(cashPayment.getPayment()))
+                .build();
+    }
+
+    public static PaymentDto toDto(CreditPayment creditPayment) {
+        return CreditPaymentDto.builder()
+                .creditPaymentId(creditPayment.getId())
+                .bank(creditPayment.getBank())
+                .cardNumber(creditPayment.getCardNumber())
+                .name(creditPayment.getName())
+                .paymentDto(toDto(creditPayment.getPayment()))
+                .build();
+    }
+
+    public static PaymentDto toDto(MobilePayment mobilePayment) {
+        return MobilePaymentDto.builder()
+                .mobilePaymentId(mobilePayment.getId())
+                .phone(mobilePayment.getPhone())
+                .telco(mobilePayment.getTelco())
+                .name(mobilePayment.getName())
+                .paymentDto(toDto(mobilePayment.getPayment()))
+                .build();
+    }
+}

--- a/src/main/java/me/jjeda/mall/orders/domain/PaymentFactory.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/PaymentFactory.java
@@ -1,36 +1,32 @@
 package me.jjeda.mall.orders.domain;
 
-import lombok.RequiredArgsConstructor;
 import me.jjeda.mall.orders.service.CashPaymentService;
 import me.jjeda.mall.orders.service.CreditPaymentService;
 import me.jjeda.mall.orders.service.MobilePaymentService;
 import me.jjeda.mall.orders.service.PaymentService;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Component
-@RequiredArgsConstructor
 public class PaymentFactory {
 
-    private final CashPaymentService cashPaymentService;
-    private final CreditPaymentService creditPaymentService;
-    private final MobilePaymentService mobilePaymentService;
+    private final Map<PaymentType, PaymentService> map;
+
+    public PaymentFactory(CashPaymentService cashPaymentService, CreditPaymentService creditPaymentService,
+                          MobilePaymentService mobilePaymentService) {
+        map = new HashMap<>();
+        map.put(PaymentType.CASH, cashPaymentService);
+        map.put(PaymentType.CREDIT, creditPaymentService);
+        map.put(PaymentType.MOBILE, mobilePaymentService);
+    }
 
     public PaymentService getType(PaymentType paymentType) {
-        final PaymentService paymentService;
-
-        switch (paymentType) {
-            case CASH:
-                paymentService = cashPaymentService;
-                break;
-            case CREDIT:
-                paymentService = creditPaymentService;
-                break;
-            case MOBILE:
-                paymentService = mobilePaymentService;
-                break;
-            default:
-                throw new IllegalArgumentException();
+        if(map.containsKey(paymentType)) {
+            return map.get(paymentType);
+        } else {
+            throw new IllegalArgumentException();
         }
-        return paymentService;
     }
 }

--- a/src/main/java/me/jjeda/mall/orders/domain/PaymentFactory.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/PaymentFactory.java
@@ -1,0 +1,36 @@
+package me.jjeda.mall.orders.domain;
+
+import lombok.RequiredArgsConstructor;
+import me.jjeda.mall.orders.service.CashPaymentService;
+import me.jjeda.mall.orders.service.CreditPaymentService;
+import me.jjeda.mall.orders.service.MobilePaymentService;
+import me.jjeda.mall.orders.service.PaymentService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentFactory {
+
+    private final CashPaymentService cashPaymentService;
+    private final CreditPaymentService creditPaymentService;
+    private final MobilePaymentService mobilePaymentService;
+
+    public PaymentService getType(PaymentType paymentType) {
+        final PaymentService paymentService;
+
+        switch (paymentType) {
+            case CASH:
+                paymentService = cashPaymentService;
+                break;
+            case CREDIT:
+                paymentService = creditPaymentService;
+                break;
+            case MOBILE:
+                paymentService = mobilePaymentService;
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+        return paymentService;
+    }
+}

--- a/src/main/java/me/jjeda/mall/orders/domain/PaymentStatus.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/PaymentStatus.java
@@ -1,0 +1,12 @@
+package me.jjeda.mall.orders.domain;
+
+/**
+ * 결제상태를 나타내는 enum
+ * READY : 결제전
+ * COMP :결제완료
+ * CANCEL : 결제취소
+ * REFUND : 환불
+ */
+public enum PaymentStatus {
+    READY, COMP, CANCEL, REFUND
+}

--- a/src/main/java/me/jjeda/mall/orders/domain/PaymentType.java
+++ b/src/main/java/me/jjeda/mall/orders/domain/PaymentType.java
@@ -1,0 +1,11 @@
+package me.jjeda.mall.orders.domain;
+
+/**
+ * 결제 수단
+ * CREDIT : (신용)카드
+ * CASH : 계좌이체
+ * MOBILE : 모바일
+ */
+public enum PaymentType {
+    CREDIT, CASH, MOBILE
+}

--- a/src/main/java/me/jjeda/mall/orders/dto/CashPaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/CashPaymentDto.java
@@ -1,0 +1,30 @@
+package me.jjeda.mall.orders.dto;
+
+import me.jjeda.mall.orders.domain.CashPayment;
+
+public class CashPaymentDto extends PaymentDto {
+
+    private Long cashPaymentId;
+
+    private String bank;
+
+    private String bankAccount;
+
+    private String name;
+
+    private PaymentDto paymentDto;
+
+    public CashPayment toEntity() {
+        return CashPayment.builder()
+                .id(this.cashPaymentId)
+                .bank(this.bank)
+                .bankAccount(this.bankAccount)
+                .name(this.name)
+                .payment(paymentDto.toPaymentEntity())
+                .build();
+    }
+    public static PaymentDto toDto(CashPayment cashPayment) {
+        return CashPaymentDto.builder()
+                .build();
+    }
+}

--- a/src/main/java/me/jjeda/mall/orders/dto/CashPaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/CashPaymentDto.java
@@ -1,7 +1,10 @@
 package me.jjeda.mall.orders.dto;
 
-import me.jjeda.mall.orders.domain.CashPayment;
+import lombok.Builder;
+import lombok.Getter;
 
+@Getter
+@Builder
 public class CashPaymentDto extends PaymentDto {
 
     private Long cashPaymentId;
@@ -13,18 +16,4 @@ public class CashPaymentDto extends PaymentDto {
     private String name;
 
     private PaymentDto paymentDto;
-
-    public CashPayment toEntity() {
-        return CashPayment.builder()
-                .id(this.cashPaymentId)
-                .bank(this.bank)
-                .bankAccount(this.bankAccount)
-                .name(this.name)
-                .payment(paymentDto.toPaymentEntity())
-                .build();
-    }
-    public static PaymentDto toDto(CashPayment cashPayment) {
-        return CashPaymentDto.builder()
-                .build();
-    }
 }

--- a/src/main/java/me/jjeda/mall/orders/dto/CashPaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/CashPaymentDto.java
@@ -1,10 +1,10 @@
 package me.jjeda.mall.orders.dto;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
+@SuperBuilder
 public class CashPaymentDto extends PaymentDto {
 
     private Long cashPaymentId;
@@ -14,6 +14,4 @@ public class CashPaymentDto extends PaymentDto {
     private String bankAccount;
 
     private String name;
-
-    private PaymentDto paymentDto;
 }

--- a/src/main/java/me/jjeda/mall/orders/dto/CreditPaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/CreditPaymentDto.java
@@ -1,0 +1,4 @@
+package me.jjeda.mall.orders.dto;
+
+public class CreditPaymentDto extends PaymentDto {
+}

--- a/src/main/java/me/jjeda/mall/orders/dto/CreditPaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/CreditPaymentDto.java
@@ -1,4 +1,19 @@
 package me.jjeda.mall.orders.dto;
 
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
 public class CreditPaymentDto extends PaymentDto {
+
+    private Long creditPaymentId;
+
+    private String bank;
+
+    private String cardNumber;
+
+    private String name;
+
+    private PaymentDto paymentDto;
 }

--- a/src/main/java/me/jjeda/mall/orders/dto/CreditPaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/CreditPaymentDto.java
@@ -1,10 +1,10 @@
 package me.jjeda.mall.orders.dto;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
+@SuperBuilder
 public class CreditPaymentDto extends PaymentDto {
 
     private Long creditPaymentId;
@@ -14,6 +14,4 @@ public class CreditPaymentDto extends PaymentDto {
     private String cardNumber;
 
     private String name;
-
-    private PaymentDto paymentDto;
 }

--- a/src/main/java/me/jjeda/mall/orders/dto/MobilePaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/MobilePaymentDto.java
@@ -1,0 +1,4 @@
+package me.jjeda.mall.orders.dto;
+
+public class MobilePaymentDto extends PaymentDto {
+}

--- a/src/main/java/me/jjeda/mall/orders/dto/MobilePaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/MobilePaymentDto.java
@@ -1,10 +1,10 @@
 package me.jjeda.mall.orders.dto;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
+@SuperBuilder
 public class MobilePaymentDto extends PaymentDto {
 
     private Long mobilePaymentId;
@@ -14,6 +14,4 @@ public class MobilePaymentDto extends PaymentDto {
     private String telco;
 
     private String name;
-
-    private PaymentDto paymentDto;
 }

--- a/src/main/java/me/jjeda/mall/orders/dto/MobilePaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/MobilePaymentDto.java
@@ -1,4 +1,19 @@
 package me.jjeda.mall.orders.dto;
 
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
 public class MobilePaymentDto extends PaymentDto {
+
+    private Long mobilePaymentId;
+
+    private String phone;
+
+    private String telco;
+
+    private String name;
+
+    private PaymentDto paymentDto;
 }

--- a/src/main/java/me/jjeda/mall/orders/dto/OrderDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/OrderDto.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 import me.jjeda.mall.orders.domain.Order;
 import me.jjeda.mall.orders.domain.OrderItem;
 import me.jjeda.mall.orders.domain.OrderStatus;
+import me.jjeda.mall.orders.domain.Payment;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -32,7 +33,7 @@ public class OrderDto {
         return Order.builder()
                 .delivery(this.deliveryDto.toEntity())
                 .orderItems(tempOrderItems)
-                .payment(PaymentDto.toReadyEntity())
+                .payment(Payment.toReadyEntity())
                 .status(OrderStatus.ORDER)
                 .orderAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/me/jjeda/mall/orders/dto/OrderDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/OrderDto.java
@@ -27,11 +27,12 @@ public class OrderDto {
 
     public Order toEntity() {
         List<OrderItem> tempOrderItems = new ArrayList<>();
-        orderItemDtoList.forEach((dto)->tempOrderItems.add(dto.toEntity()));
+        orderItemDtoList.forEach((dto) -> tempOrderItems.add(dto.toEntity()));
 
         return Order.builder()
                 .delivery(this.deliveryDto.toEntity())
                 .orderItems(tempOrderItems)
+                .payment(PaymentDto.toReadyEntity())
                 .status(OrderStatus.ORDER)
                 .orderAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/me/jjeda/mall/orders/dto/PaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/PaymentDto.java
@@ -1,13 +1,16 @@
 package me.jjeda.mall.orders.dto;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import me.jjeda.mall.orders.domain.Payment;
 import me.jjeda.mall.orders.domain.PaymentStatus;
 import me.jjeda.mall.orders.domain.PaymentType;
 
 @Builder
 @Getter
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
 public class PaymentDto {
 
     private Long id;
@@ -22,5 +25,8 @@ public class PaymentDto {
         return Payment.builder()
                 .paymentStatus(PaymentStatus.READY)
                 .build();
+    }
+    public Payment toPaymentEntity() {
+        return null;
     }
 }

--- a/src/main/java/me/jjeda/mall/orders/dto/PaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/PaymentDto.java
@@ -1,17 +1,18 @@
 package me.jjeda.mall.orders.dto;
 
-import lombok.AccessLevel;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 import me.jjeda.mall.orders.domain.PaymentStatus;
 import me.jjeda.mall.orders.domain.PaymentType;
 
 import java.time.LocalDateTime;
 
-@Builder
+@SuperBuilder
 @Getter
-@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@Setter
+@AllArgsConstructor
 public class PaymentDto {
 
     private Long id;
@@ -23,4 +24,6 @@ public class PaymentDto {
     private PaymentType paymentType;
 
     private LocalDateTime createdAt;
+
+    private PaymentDto superTypePaymentDto;
 }

--- a/src/main/java/me/jjeda/mall/orders/dto/PaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/PaymentDto.java
@@ -4,9 +4,10 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import me.jjeda.mall.orders.domain.Payment;
 import me.jjeda.mall.orders.domain.PaymentStatus;
 import me.jjeda.mall.orders.domain.PaymentType;
+
+import java.time.LocalDateTime;
 
 @Builder
 @Getter
@@ -21,12 +22,5 @@ public class PaymentDto {
 
     private PaymentType paymentType;
 
-    public static Payment toReadyEntity() {
-        return Payment.builder()
-                .paymentStatus(PaymentStatus.READY)
-                .build();
-    }
-    public Payment toPaymentEntity() {
-        return null;
-    }
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/me/jjeda/mall/orders/dto/PaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/PaymentDto.java
@@ -1,0 +1,4 @@
+package me.jjeda.mall.orders.dto;
+
+public class PaymentDto {
+}

--- a/src/main/java/me/jjeda/mall/orders/dto/PaymentDto.java
+++ b/src/main/java/me/jjeda/mall/orders/dto/PaymentDto.java
@@ -1,4 +1,26 @@
 package me.jjeda.mall.orders.dto;
 
+import lombok.Builder;
+import lombok.Getter;
+import me.jjeda.mall.orders.domain.Payment;
+import me.jjeda.mall.orders.domain.PaymentStatus;
+import me.jjeda.mall.orders.domain.PaymentType;
+
+@Builder
+@Getter
 public class PaymentDto {
+
+    private Long id;
+
+    private int price;
+
+    private PaymentStatus paymentStatus;
+
+    private PaymentType paymentType;
+
+    public static Payment toReadyEntity() {
+        return Payment.builder()
+                .paymentStatus(PaymentStatus.READY)
+                .build();
+    }
 }

--- a/src/main/java/me/jjeda/mall/orders/repository/CashPaymentRepository.java
+++ b/src/main/java/me/jjeda/mall/orders/repository/CashPaymentRepository.java
@@ -1,0 +1,7 @@
+package me.jjeda.mall.orders.repository;
+
+import me.jjeda.mall.orders.domain.CashPayment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CashPaymentRepository extends JpaRepository<CashPayment, Long> {
+}

--- a/src/main/java/me/jjeda/mall/orders/repository/CreditPaymentRepository.java
+++ b/src/main/java/me/jjeda/mall/orders/repository/CreditPaymentRepository.java
@@ -1,0 +1,8 @@
+package me.jjeda.mall.orders.repository;
+
+import me.jjeda.mall.orders.domain.CreditPayment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CreditPaymentRepository extends JpaRepository<CreditPayment, Long> {
+
+}

--- a/src/main/java/me/jjeda/mall/orders/repository/MobilePaymentRepository.java
+++ b/src/main/java/me/jjeda/mall/orders/repository/MobilePaymentRepository.java
@@ -1,0 +1,7 @@
+package me.jjeda.mall.orders.repository;
+
+import me.jjeda.mall.orders.domain.MobilePayment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MobilePaymentRepository extends JpaRepository<MobilePayment, Long> {
+}

--- a/src/main/java/me/jjeda/mall/orders/repository/PaymentRepository.java
+++ b/src/main/java/me/jjeda/mall/orders/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package me.jjeda.mall.orders.repository;
+
+import me.jjeda.mall.orders.domain.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/me/jjeda/mall/orders/service/CashPaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/CashPaymentService.java
@@ -1,0 +1,18 @@
+package me.jjeda.mall.orders.service;
+
+import lombok.RequiredArgsConstructor;
+import me.jjeda.mall.orders.dto.PaymentDto;
+import me.jjeda.mall.orders.repository.CashPaymentRepository;
+import me.jjeda.mall.orders.repository.PaymentRepository;
+
+@RequiredArgsConstructor
+public class CashPaymentService implements PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final CashPaymentRepository cashPaymentRepository;
+
+    @Override
+    public PaymentDto payForOrder(PaymentDto paymentDto, Long orderId) {
+        return null;
+    }
+}

--- a/src/main/java/me/jjeda/mall/orders/service/CashPaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/CashPaymentService.java
@@ -1,54 +1,29 @@
 package me.jjeda.mall.orders.service;
 
 import lombok.RequiredArgsConstructor;
-import me.jjeda.mall.items.service.ItemService;
 import me.jjeda.mall.orders.domain.CashPayment;
-import me.jjeda.mall.orders.domain.Order;
-import me.jjeda.mall.orders.domain.OrderItem;
 import me.jjeda.mall.orders.domain.Payment;
-import me.jjeda.mall.orders.domain.PaymentStatus;
+import me.jjeda.mall.orders.domain.PaymentAdapter;
 import me.jjeda.mall.orders.dto.CashPaymentDto;
 import me.jjeda.mall.orders.dto.PaymentDto;
 import me.jjeda.mall.orders.repository.CashPaymentRepository;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 @RequiredArgsConstructor
+@Service
 public class CashPaymentService implements PaymentService {
 
     private final CashPaymentRepository cashPaymentRepository;
-    private final OrderService orderService;
-    private final ItemService itemService;
 
     @Override
     @Transactional
-    public PaymentDto payForOrder(PaymentDto paymentDto, Long orderId) {
-        //TODO : [#40] 탬플릿-콜백 패턴으로 공통부분 재사용코드로 만들기(각 결제 정보 저장로직만 다름)
-        Order order = orderService.getOrder(orderId);
-        Payment payment = order.getPayment();
-        List<OrderItem> orderItems = order.getOrderItems();
-
-        payment = Payment.builder()
-                .paymentStatus(PaymentStatus.COMP)
-                .id(payment.getId())
-                .price(order.getTotalPrice())
-                .createdAt(LocalDateTime.now())
-                .paymentType(paymentDto.getPaymentType())
-                .build();
-
-        /* 주문이 완료되면 아이템의 전체 재고에서 주문수량만큼 빼주어야한다. */
-        //TODO : N+1문제 -> 벌크호출
-        orderItems.forEach((orderItem) ->
-                itemService.decrementStock(orderItem.getItem().getId(), orderItem.getQuantity())
-        );
-
+    public PaymentDto savePaymentInfo(PaymentDto paymentDto, Payment payment) {
         CashPaymentDto cashPaymentDto = (CashPaymentDto) paymentDto;
-        CashPayment cashPayment = cashPaymentDto.toEntity();
+        CashPayment cashPayment = PaymentAdapter.toEntity(cashPaymentDto);
         cashPayment.setPayment(payment);
         cashPaymentRepository.save(cashPayment);
 
-        return CashPaymentDto.toDto(cashPayment);
+        return PaymentAdapter.toDto(cashPayment);
     }
 }

--- a/src/main/java/me/jjeda/mall/orders/service/CashPaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/CashPaymentService.java
@@ -2,11 +2,12 @@ package me.jjeda.mall.orders.service;
 
 import lombok.RequiredArgsConstructor;
 import me.jjeda.mall.items.service.ItemService;
+import me.jjeda.mall.orders.domain.CashPayment;
 import me.jjeda.mall.orders.domain.Order;
 import me.jjeda.mall.orders.domain.OrderItem;
 import me.jjeda.mall.orders.domain.Payment;
 import me.jjeda.mall.orders.domain.PaymentStatus;
-import me.jjeda.mall.orders.domain.PaymentType;
+import me.jjeda.mall.orders.dto.CashPaymentDto;
 import me.jjeda.mall.orders.dto.PaymentDto;
 import me.jjeda.mall.orders.repository.CashPaymentRepository;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +24,7 @@ public class CashPaymentService implements PaymentService {
 
     @Override
     @Transactional
-    public Payment payForOrder(PaymentDto paymentDto, Long orderId) {
+    public PaymentDto payForOrder(PaymentDto paymentDto, Long orderId) {
         //TODO : [#40] 탬플릿-콜백 패턴으로 공통부분 재사용코드로 만들기(각 결제 정보 저장로직만 다름)
         Order order = orderService.getOrder(orderId);
         Payment payment = order.getPayment();
@@ -34,7 +35,7 @@ public class CashPaymentService implements PaymentService {
                 .id(payment.getId())
                 .price(order.getTotalPrice())
                 .createdAt(LocalDateTime.now())
-                .paymentType(PaymentType.CASH)
+                .paymentType(paymentDto.getPaymentType())
                 .build();
 
         /* 주문이 완료되면 아이템의 전체 재고에서 주문수량만큼 빼주어야한다. */
@@ -43,8 +44,11 @@ public class CashPaymentService implements PaymentService {
                 itemService.decrementStock(orderItem.getItem().getId(), orderItem.getQuantity())
         );
 
-        // TODO : cashPaymentRepository 를 통해 현금결제 정보를 저장해야함
+        CashPaymentDto cashPaymentDto = (CashPaymentDto) paymentDto;
+        CashPayment cashPayment = cashPaymentDto.toEntity();
+        cashPayment.setPayment(payment);
+        cashPaymentRepository.save(cashPayment);
 
-        return payment;
+        return CashPaymentDto.toDto(cashPayment);
     }
 }

--- a/src/main/java/me/jjeda/mall/orders/service/CashPaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/CashPaymentService.java
@@ -2,7 +2,6 @@ package me.jjeda.mall.orders.service;
 
 import lombok.RequiredArgsConstructor;
 import me.jjeda.mall.orders.domain.CashPayment;
-import me.jjeda.mall.orders.domain.Payment;
 import me.jjeda.mall.orders.domain.PaymentAdapter;
 import me.jjeda.mall.orders.dto.CashPaymentDto;
 import me.jjeda.mall.orders.dto.PaymentDto;
@@ -18,10 +17,9 @@ public class CashPaymentService implements PaymentService {
 
     @Override
     @Transactional
-    public PaymentDto savePaymentInfo(PaymentDto paymentDto, Payment payment) {
+    public PaymentDto savePaymentInfo(PaymentDto paymentDto) {
         CashPaymentDto cashPaymentDto = (CashPaymentDto) paymentDto;
         CashPayment cashPayment = PaymentAdapter.toEntity(cashPaymentDto);
-        cashPayment.setPayment(payment);
         cashPaymentRepository.save(cashPayment);
 
         return PaymentAdapter.toDto(cashPayment);

--- a/src/main/java/me/jjeda/mall/orders/service/CashPaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/CashPaymentService.java
@@ -1,18 +1,50 @@
 package me.jjeda.mall.orders.service;
 
 import lombok.RequiredArgsConstructor;
+import me.jjeda.mall.items.service.ItemService;
+import me.jjeda.mall.orders.domain.Order;
+import me.jjeda.mall.orders.domain.OrderItem;
+import me.jjeda.mall.orders.domain.Payment;
+import me.jjeda.mall.orders.domain.PaymentStatus;
+import me.jjeda.mall.orders.domain.PaymentType;
 import me.jjeda.mall.orders.dto.PaymentDto;
 import me.jjeda.mall.orders.repository.CashPaymentRepository;
-import me.jjeda.mall.orders.repository.PaymentRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @RequiredArgsConstructor
 public class CashPaymentService implements PaymentService {
 
-    private final PaymentRepository paymentRepository;
     private final CashPaymentRepository cashPaymentRepository;
+    private final OrderService orderService;
+    private final ItemService itemService;
 
     @Override
-    public PaymentDto payForOrder(PaymentDto paymentDto, Long orderId) {
-        return null;
+    @Transactional
+    public Payment payForOrder(PaymentDto paymentDto, Long orderId) {
+        //TODO : [#40] 탬플릿-콜백 패턴으로 공통부분 재사용코드로 만들기(각 결제 정보 저장로직만 다름)
+        Order order = orderService.getOrder(orderId);
+        Payment payment = order.getPayment();
+        List<OrderItem> orderItems = order.getOrderItems();
+
+        payment = Payment.builder()
+                .paymentStatus(PaymentStatus.COMP)
+                .id(payment.getId())
+                .price(order.getTotalPrice())
+                .createdAt(LocalDateTime.now())
+                .paymentType(PaymentType.CASH)
+                .build();
+
+        /* 주문이 완료되면 아이템의 전체 재고에서 주문수량만큼 빼주어야한다. */
+        //TODO : N+1문제 -> 벌크호출
+        orderItems.forEach((orderItem) ->
+                itemService.decrementStock(orderItem.getItem().getId(), orderItem.getQuantity())
+        );
+
+        // TODO : cashPaymentRepository 를 통해 현금결제 정보를 저장해야함
+
+        return payment;
     }
 }

--- a/src/main/java/me/jjeda/mall/orders/service/CreditPaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/CreditPaymentService.java
@@ -1,0 +1,18 @@
+package me.jjeda.mall.orders.service;
+
+import lombok.RequiredArgsConstructor;
+import me.jjeda.mall.orders.dto.PaymentDto;
+import me.jjeda.mall.orders.repository.CreditPaymentRepository;
+import me.jjeda.mall.orders.repository.PaymentRepository;
+
+@RequiredArgsConstructor
+public class CreditPaymentService implements PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final CreditPaymentRepository creditPaymentRepository;
+
+    @Override
+    public PaymentDto payForOrder(PaymentDto paymentDto, Long orderId) {
+        return null;
+    }
+}

--- a/src/main/java/me/jjeda/mall/orders/service/CreditPaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/CreditPaymentService.java
@@ -2,7 +2,6 @@ package me.jjeda.mall.orders.service;
 
 import lombok.RequiredArgsConstructor;
 import me.jjeda.mall.orders.domain.CreditPayment;
-import me.jjeda.mall.orders.domain.Payment;
 import me.jjeda.mall.orders.domain.PaymentAdapter;
 import me.jjeda.mall.orders.dto.CreditPaymentDto;
 import me.jjeda.mall.orders.dto.PaymentDto;
@@ -18,10 +17,9 @@ public class CreditPaymentService implements PaymentService {
 
     @Override
     @Transactional
-    public PaymentDto savePaymentInfo(PaymentDto paymentDto, Payment payment) {
+    public PaymentDto savePaymentInfo(PaymentDto paymentDto) {
         CreditPaymentDto creditPaymentDto = (CreditPaymentDto) paymentDto;
         CreditPayment creditPayment = PaymentAdapter.toEntity(creditPaymentDto);
-        creditPayment.setPayment(payment);
         creditPaymentRepository.save(creditPayment);
 
         return PaymentAdapter.toDto(creditPayment);

--- a/src/main/java/me/jjeda/mall/orders/service/CreditPaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/CreditPaymentService.java
@@ -1,6 +1,7 @@
 package me.jjeda.mall.orders.service;
 
 import lombok.RequiredArgsConstructor;
+import me.jjeda.mall.orders.domain.Payment;
 import me.jjeda.mall.orders.dto.PaymentDto;
 import me.jjeda.mall.orders.repository.CreditPaymentRepository;
 import me.jjeda.mall.orders.repository.PaymentRepository;
@@ -12,7 +13,8 @@ public class CreditPaymentService implements PaymentService {
     private final CreditPaymentRepository creditPaymentRepository;
 
     @Override
-    public PaymentDto payForOrder(PaymentDto paymentDto, Long orderId) {
+    public Payment payForOrder(PaymentDto paymentDto, Long orderId) {
         return null;
     }
+
 }

--- a/src/main/java/me/jjeda/mall/orders/service/CreditPaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/CreditPaymentService.java
@@ -13,7 +13,7 @@ public class CreditPaymentService implements PaymentService {
     private final CreditPaymentRepository creditPaymentRepository;
 
     @Override
-    public Payment payForOrder(PaymentDto paymentDto, Long orderId) {
+    public PaymentDto payForOrder(PaymentDto paymentDto, Long orderId) {
         return null;
     }
 

--- a/src/main/java/me/jjeda/mall/orders/service/CreditPaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/CreditPaymentService.java
@@ -1,20 +1,30 @@
 package me.jjeda.mall.orders.service;
 
 import lombok.RequiredArgsConstructor;
+import me.jjeda.mall.orders.domain.CreditPayment;
 import me.jjeda.mall.orders.domain.Payment;
+import me.jjeda.mall.orders.domain.PaymentAdapter;
+import me.jjeda.mall.orders.dto.CreditPaymentDto;
 import me.jjeda.mall.orders.dto.PaymentDto;
 import me.jjeda.mall.orders.repository.CreditPaymentRepository;
-import me.jjeda.mall.orders.repository.PaymentRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
+@Service
 public class CreditPaymentService implements PaymentService {
 
-    private final PaymentRepository paymentRepository;
     private final CreditPaymentRepository creditPaymentRepository;
 
     @Override
-    public PaymentDto payForOrder(PaymentDto paymentDto, Long orderId) {
-        return null;
+    @Transactional
+    public PaymentDto savePaymentInfo(PaymentDto paymentDto, Payment payment) {
+        CreditPaymentDto creditPaymentDto = (CreditPaymentDto) paymentDto;
+        CreditPayment creditPayment = PaymentAdapter.toEntity(creditPaymentDto);
+        creditPayment.setPayment(payment);
+        creditPaymentRepository.save(creditPayment);
+
+        return PaymentAdapter.toDto(creditPayment);
     }
 
 }

--- a/src/main/java/me/jjeda/mall/orders/service/MobilePaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/MobilePaymentService.java
@@ -1,0 +1,18 @@
+package me.jjeda.mall.orders.service;
+
+import lombok.RequiredArgsConstructor;
+import me.jjeda.mall.orders.dto.PaymentDto;
+import me.jjeda.mall.orders.repository.MobilePaymentRepository;
+import me.jjeda.mall.orders.repository.PaymentRepository;
+
+@RequiredArgsConstructor
+public class MobilePaymentService implements PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final MobilePaymentRepository mobilePaymentRepository;
+
+    @Override
+    public PaymentDto payForOrder(PaymentDto paymentDto, Long orderId) {
+        return null;
+    }
+}

--- a/src/main/java/me/jjeda/mall/orders/service/MobilePaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/MobilePaymentService.java
@@ -1,18 +1,29 @@
 package me.jjeda.mall.orders.service;
 
 import lombok.RequiredArgsConstructor;
+import me.jjeda.mall.orders.domain.MobilePayment;
+import me.jjeda.mall.orders.domain.Payment;
+import me.jjeda.mall.orders.domain.PaymentAdapter;
+import me.jjeda.mall.orders.dto.MobilePaymentDto;
 import me.jjeda.mall.orders.dto.PaymentDto;
 import me.jjeda.mall.orders.repository.MobilePaymentRepository;
-import me.jjeda.mall.orders.repository.PaymentRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
+@Service
 public class MobilePaymentService implements PaymentService {
 
-    private final PaymentRepository paymentRepository;
     private final MobilePaymentRepository mobilePaymentRepository;
 
     @Override
-    public PaymentDto payForOrder(PaymentDto paymentDto, Long orderId) {
-        return null;
+    @Transactional
+    public PaymentDto savePaymentInfo(PaymentDto paymentDto, Payment payment) {
+        MobilePaymentDto mobilePaymentDto = (MobilePaymentDto) paymentDto;
+        MobilePayment mobilePayment = PaymentAdapter.toEntity(mobilePaymentDto);
+        mobilePayment.setPayment(payment);
+        mobilePaymentRepository.save(mobilePayment);
+
+        return PaymentAdapter.toDto(mobilePayment);
     }
 }

--- a/src/main/java/me/jjeda/mall/orders/service/MobilePaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/MobilePaymentService.java
@@ -2,7 +2,6 @@ package me.jjeda.mall.orders.service;
 
 import lombok.RequiredArgsConstructor;
 import me.jjeda.mall.orders.domain.MobilePayment;
-import me.jjeda.mall.orders.domain.Payment;
 import me.jjeda.mall.orders.domain.PaymentAdapter;
 import me.jjeda.mall.orders.dto.MobilePaymentDto;
 import me.jjeda.mall.orders.dto.PaymentDto;
@@ -18,10 +17,9 @@ public class MobilePaymentService implements PaymentService {
 
     @Override
     @Transactional
-    public PaymentDto savePaymentInfo(PaymentDto paymentDto, Payment payment) {
+    public PaymentDto savePaymentInfo(PaymentDto paymentDto) {
         MobilePaymentDto mobilePaymentDto = (MobilePaymentDto) paymentDto;
         MobilePayment mobilePayment = PaymentAdapter.toEntity(mobilePaymentDto);
-        mobilePayment.setPayment(payment);
         mobilePaymentRepository.save(mobilePayment);
 
         return PaymentAdapter.toDto(mobilePayment);

--- a/src/main/java/me/jjeda/mall/orders/service/MobilePaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/MobilePaymentService.java
@@ -1,6 +1,7 @@
 package me.jjeda.mall.orders.service;
 
 import lombok.RequiredArgsConstructor;
+import me.jjeda.mall.orders.domain.Payment;
 import me.jjeda.mall.orders.dto.PaymentDto;
 import me.jjeda.mall.orders.repository.MobilePaymentRepository;
 import me.jjeda.mall.orders.repository.PaymentRepository;
@@ -12,7 +13,7 @@ public class MobilePaymentService implements PaymentService {
     private final MobilePaymentRepository mobilePaymentRepository;
 
     @Override
-    public PaymentDto payForOrder(PaymentDto paymentDto, Long orderId) {
+    public Payment payForOrder(PaymentDto paymentDto, Long orderId) {
         return null;
     }
 }

--- a/src/main/java/me/jjeda/mall/orders/service/MobilePaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/MobilePaymentService.java
@@ -1,7 +1,6 @@
 package me.jjeda.mall.orders.service;
 
 import lombok.RequiredArgsConstructor;
-import me.jjeda.mall.orders.domain.Payment;
 import me.jjeda.mall.orders.dto.PaymentDto;
 import me.jjeda.mall.orders.repository.MobilePaymentRepository;
 import me.jjeda.mall.orders.repository.PaymentRepository;
@@ -13,7 +12,7 @@ public class MobilePaymentService implements PaymentService {
     private final MobilePaymentRepository mobilePaymentRepository;
 
     @Override
-    public Payment payForOrder(PaymentDto paymentDto, Long orderId) {
+    public PaymentDto payForOrder(PaymentDto paymentDto, Long orderId) {
         return null;
     }
 }

--- a/src/main/java/me/jjeda/mall/orders/service/OrderService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/OrderService.java
@@ -4,14 +4,13 @@ import lombok.RequiredArgsConstructor;
 import me.jjeda.mall.accounts.domain.AccountAndDtoAdapter;
 import me.jjeda.mall.accounts.dto.AccountDto;
 import me.jjeda.mall.items.service.ItemService;
-import me.jjeda.mall.orders.domain.CashPayment;
 import me.jjeda.mall.orders.domain.DeliveryStatus;
 import me.jjeda.mall.orders.domain.Order;
 import me.jjeda.mall.orders.domain.OrderItem;
 import me.jjeda.mall.orders.domain.OrderStatus;
 import me.jjeda.mall.orders.domain.Payment;
+import me.jjeda.mall.orders.domain.PaymentAdapter;
 import me.jjeda.mall.orders.domain.PaymentStatus;
-import me.jjeda.mall.orders.dto.CashPaymentDto;
 import me.jjeda.mall.orders.dto.OrderDto;
 import me.jjeda.mall.orders.dto.PaymentDto;
 import me.jjeda.mall.orders.repository.OrderRepository;
@@ -90,19 +89,18 @@ public class OrderService {
         Payment payment = order.getPayment();
         List<OrderItem> orderItems = order.getOrderItems();
 
-        payment = Payment.builder()
-                .paymentStatus(PaymentStatus.COMP)
-                .id(payment.getId())
-                .price(order.getTotalPrice())
-                .createdAt(LocalDateTime.now())
-                .paymentType(paymentDto.getPaymentType())
-                .build();
+        payment.setPaymentStatus(PaymentStatus.COMP);
+        payment.setPaymentType(paymentDto.getPaymentType());
+        payment.setCreatedAt(LocalDateTime.now());
+        payment.setPrice(paymentDto.getPrice());
+
+        paymentDto.setSuperTypePaymentDto(PaymentAdapter.toDto(payment));
 
         /* 주문이 완료되면 아이템의 전체 재고에서 주문수량만큼 빼주어야한다. */
         //TODO : N+1문제 -> 벌크호출
         orderItems.forEach((orderItem) ->
                 itemService.decrementStock(orderItem.getItem().getId(), orderItem.getQuantity())
         );
-        return paymentService.savePaymentInfo(paymentDto, payment);
+        return paymentService.savePaymentInfo(paymentDto);
     }
 }

--- a/src/main/java/me/jjeda/mall/orders/service/OrderService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/OrderService.java
@@ -10,6 +10,7 @@ import me.jjeda.mall.orders.domain.OrderItem;
 import me.jjeda.mall.orders.domain.OrderStatus;
 import me.jjeda.mall.orders.dto.OrderDto;
 import me.jjeda.mall.orders.repository.OrderRepository;
+import me.jjeda.mall.orders.repository.PaymentRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +23,7 @@ import java.util.Objects;
 public class OrderService {
     private final OrderRepository orderRepository;
     private final ItemService itemService;
+    private final PaymentRepository paymentRepository;
 
     @Transactional
     public Order createOrder(OrderDto orderDto, AccountDto accountDto) {

--- a/src/main/java/me/jjeda/mall/orders/service/OrderService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/OrderService.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 public class OrderService {
     private final OrderRepository orderRepository;
     private final ItemService itemService;
-    private final PaymentRepository paymentRepository;
 
     @Transactional
     public Order createOrder(OrderDto orderDto, AccountDto accountDto) {

--- a/src/main/java/me/jjeda/mall/orders/service/PaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/PaymentService.java
@@ -1,12 +1,11 @@
 package me.jjeda.mall.orders.service;
 
-import me.jjeda.mall.orders.domain.Payment;
 import me.jjeda.mall.orders.dto.PaymentDto;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface PaymentService {
 
-    Payment payForOrder(PaymentDto paymentDto, Long orderId);
+    PaymentDto payForOrder(PaymentDto paymentDto, Long orderId);
 
 }

--- a/src/main/java/me/jjeda/mall/orders/service/PaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/PaymentService.java
@@ -1,11 +1,11 @@
 package me.jjeda.mall.orders.service;
 
+import me.jjeda.mall.orders.domain.Payment;
 import me.jjeda.mall.orders.dto.PaymentDto;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public interface PaymentService {
-
-    PaymentDto payForOrder(PaymentDto paymentDto, Long orderId);
-
+    PaymentDto savePaymentInfo(PaymentDto paymentDto, Payment payment);
 }

--- a/src/main/java/me/jjeda/mall/orders/service/PaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/PaymentService.java
@@ -1,0 +1,11 @@
+package me.jjeda.mall.orders.service;
+
+import me.jjeda.mall.orders.dto.PaymentDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface PaymentService {
+
+    PaymentDto payForOrder(PaymentDto paymentDto, Long orderId);
+
+}

--- a/src/main/java/me/jjeda/mall/orders/service/PaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/PaymentService.java
@@ -1,11 +1,9 @@
 package me.jjeda.mall.orders.service;
 
-import me.jjeda.mall.orders.domain.Payment;
 import me.jjeda.mall.orders.dto.PaymentDto;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public interface PaymentService {
-    PaymentDto savePaymentInfo(PaymentDto paymentDto, Payment payment);
+    PaymentDto savePaymentInfo(PaymentDto paymentDto);
 }

--- a/src/main/java/me/jjeda/mall/orders/service/PaymentService.java
+++ b/src/main/java/me/jjeda/mall/orders/service/PaymentService.java
@@ -1,11 +1,12 @@
 package me.jjeda.mall.orders.service;
 
+import me.jjeda.mall.orders.domain.Payment;
 import me.jjeda.mall.orders.dto.PaymentDto;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface PaymentService {
 
-    PaymentDto payForOrder(PaymentDto paymentDto, Long orderId);
+    Payment payForOrder(PaymentDto paymentDto, Long orderId);
 
 }

--- a/src/test/java/me/jjeda/mall/orders/controller/OrderControllerTest.java
+++ b/src/test/java/me/jjeda/mall/orders/controller/OrderControllerTest.java
@@ -46,6 +46,26 @@ public class OrderControllerTest extends BaseControllerTest {
     @Autowired
     private OrderService orderService;
 
+    @Test
+    public void testPayment() throws Exception {
+
+        AccountDto buyerAccountDto = AccountDto.builder()
+                .accountRole(Set.of(AccountRole.USER))
+                .address(new Address("a", "b", "c"))
+                .email("buyer@naver.com")
+                .nickname("buyer")
+                .phone("01012341234")
+                .password("pass")
+                .build();
+        AccountDto buyerDto = accountService.saveAccount(buyerAccountDto);
+
+        mockMvc.perform(post("/api/orders/buyer/payment")
+                .header(HttpHeaders.AUTHORIZATION, getAccessToken(buyerAccountDto))
+                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .accept(MediaTypes.HAL_JSON))
+                .andDo(print());
+    }
+
 
     @TestDescription("정상적으로 주문을 완료하는 테스트")
     @Test

--- a/src/test/java/me/jjeda/mall/orders/controller/OrderControllerTest.java
+++ b/src/test/java/me/jjeda/mall/orders/controller/OrderControllerTest.java
@@ -46,27 +46,6 @@ public class OrderControllerTest extends BaseControllerTest {
     @Autowired
     private OrderService orderService;
 
-    @Test
-    public void testPayment() throws Exception {
-
-        AccountDto buyerAccountDto = AccountDto.builder()
-                .accountRole(Set.of(AccountRole.USER))
-                .address(new Address("a", "b", "c"))
-                .email("buyer@naver.com")
-                .nickname("buyer")
-                .phone("01012341234")
-                .password("pass")
-                .build();
-        AccountDto buyerDto = accountService.saveAccount(buyerAccountDto);
-
-        mockMvc.perform(post("/api/orders/buyer/payment")
-                .header(HttpHeaders.AUTHORIZATION, getAccessToken(buyerAccountDto))
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
-                .accept(MediaTypes.HAL_JSON))
-                .andDo(print());
-    }
-
-
     @TestDescription("정상적으로 주문을 완료하는 테스트")
     @Test
     @Transactional

--- a/src/test/java/me/jjeda/mall/orders/service/PaymentServiceTest.java
+++ b/src/test/java/me/jjeda/mall/orders/service/PaymentServiceTest.java
@@ -1,0 +1,63 @@
+package me.jjeda.mall.orders.service;
+
+import me.jjeda.mall.common.TestDescription;
+import me.jjeda.mall.orders.domain.CashPayment;
+import me.jjeda.mall.orders.domain.PaymentAdapter;
+import me.jjeda.mall.orders.domain.PaymentStatus;
+import me.jjeda.mall.orders.domain.PaymentType;
+import me.jjeda.mall.orders.dto.CashPaymentDto;
+import me.jjeda.mall.orders.dto.PaymentDto;
+import me.jjeda.mall.orders.repository.CashPaymentRepository;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PaymentServiceTest {
+
+    @InjectMocks
+    private CashPaymentService cashPaymentService;
+
+    @Mock
+    private CashPaymentRepository cashPaymentRepository;
+
+    @Test
+    @TestDescription("정상적으로 현금결제정보 저장하는 테스트")
+    public void savePaymentInfo_cash() {
+
+        //given
+        PaymentDto superPaymentDto = PaymentDto.builder()
+                .id(1L)
+                .paymentStatus(PaymentStatus.COMP)
+                .paymentType(PaymentType.CASH)
+                .price(10000)
+                .build();
+        CashPaymentDto cashPaymentDto = CashPaymentDto.builder()
+                .cashPaymentId(2L)
+                .name("jjeda")
+                .bank("kakao")
+                .bankAccount("1234")
+                .superTypePaymentDto(superPaymentDto)
+                .build();
+
+        //when
+        PaymentDto returnDto = cashPaymentService.savePaymentInfo(cashPaymentDto);
+        CashPaymentDto returnCashPaymentDto = (CashPaymentDto)returnDto;
+
+        assertThat(returnCashPaymentDto.getCashPaymentId()).isEqualTo(2L);
+        assertThat(returnCashPaymentDto.getName()).isEqualTo("jjeda");
+        assertThat(returnCashPaymentDto.getBank()).isEqualTo("kakao");
+        assertThat(returnCashPaymentDto.getBankAccount()).isEqualTo("1234");
+    }
+
+}


### PR DESCRIPTION
- 조인 전략으로 상속구조 매핑
- Payment 관련 Entity, Repository 생성

결제하는 방법에 3가지(카드, 계좌이체, 모바일)

3개의 클래스는 `Payment` 라는 부모 (추상)클래스를 상속받고있음 -> JPA 조인전략으로 상속관계 매핑
- 각각의 결제 방법에 따라 저장돼있는 정보가 다르기때문
- 예) 카드결제 -> 카드정보, 계좌이제 -> 입금된 계좌 정보 등

Client 측에서 결제정보를 `@RequestBody Payment payment` 로 가져옴
상위 타입에 PaymentRepository를 사용해서 DB에 저장